### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -19,7 +19,7 @@ jobs:
           DOCKER_TAGS="${BRANCH},latest"
           echo "DOCKER_TAGS=${DOCKER_TAGS}" >> $GITHUB_ENV
       - name: Publish Docker Github Action
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: unfoldingword/loki_backup
           username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore